### PR TITLE
优化Claim

### DIFF
--- a/src/service/wallet/index.ts
+++ b/src/service/wallet/index.ts
@@ -16,7 +16,7 @@ const useWalletAccounts = () => {
 
   return result;
 };
-type ClaimSuccessFunctionType = () => void;
+type ClaimSuccessFunctionType = (x: any) => void;
 type ClaimFailedFunctionType = () => void;
 
 const useWalletClaimReward = (
@@ -27,7 +27,7 @@ const useWalletClaimReward = (
   const result = useRequest(
     () =>
       contractRequestHttp.post('/xfans/api/pool/claim', {
-        list,
+        list: list?.slice(0, 2),
       }),
     {
       manual: true,

--- a/src/welcome/Profile/Claim.tsx
+++ b/src/welcome/Profile/Claim.tsx
@@ -9,13 +9,15 @@ import TableRow from '@mui/material/TableRow';
 import { useToggle } from 'ahooks';
 import BigNumber from 'bignumber.js';
 import dayjs from 'dayjs';
-import { NumberDisplayer } from '../../components/NumberDisplayer';
+
 import { BasicButton, PrimaryLoadingButton } from '../../components/Button';
 import Modal from '../../components/Modal';
+import { NumberDisplayer } from '../../components/NumberDisplayer';
 import { useTweetReward } from '../../service/tweet';
+import { useWalletClaimReward } from '../../service/wallet';
 import useTweetStore from '../../store/useTweetStore';
 import useUserStore from '../../store/useUserStore';
-import { useWalletClaimReward } from '../../service/wallet';
+import useGlobalStore from '../../store/useGlobalStore';
 
 const Icon = () => (
   <svg xmlns="http://www.w3.org/2000/svg" width="10" height="16" viewBox="0 0 10 16" fill="none">
@@ -41,18 +43,30 @@ const Claim = (props: { price?: string }) => {
   const { run: getReward } = useTweetReward();
   const { userInfo } = useUserStore((state) => ({ ...state }));
 
-  /*
-  (index=2,address=0x9eB08EE3f22bFe5c75FBa5cdd7465eE4c162e07E,amount=1000000000000, proof=["877c7a6afac7a1fb0ef4579e11d4585cb37842b5f0031649cc0528d902a82596","702a8c1786ae8aef1ee2322a325247897950a17c8de6d04edb78e096b272f0c4","e43a4e96371d12aba133cc4349d77d570db6b2776a37c9d5cd2e1e25acdbde08"])
-  (index=3,address=0x9eB08EE3f22bFe5c75FBa5cdd7465eE4c162e07E,amount=1000000000000, proof=["0637bbffaf6f1ec2bd5fc12238f0a24cee574963524781f8db2390486e5b2396","5f095dea6356c6651198e485ef419cec5f167fcebebeef886acf714f4234e744","e43a4e96371d12aba133cc4349d77d570db6b2776a37c9d5cd2e1e25acdbde08"])
-  (index=4,address=0x9eB08EE3f22bFe5c75FBa5cdd7465eE4c162e07E,amount=1000000000000, proof=["d6b667c9ea2e66dfab42a8c85b14ac0e70886f1206306cdd472b3793aea5d788","5f095dea6356c6651198e485ef419cec5f167fcebebeef886acf714f4234e744","e43a4e96371d12aba133cc4349d77d570db6b2776a37c9d5cd2e1e25acdbde08"])
-  (index=5,address=0x9eB08EE3f22bFe5c75FBa5cdd7465eE4c162e07E,amount=1000000000000, proof=["5cd70a734862fe4715ebbeeeda058344b92599ce7a5ad6b172ece947318c6c38"])
-  */
   const { loading, run: claimReward } = useWalletClaimReward(
     tweetRewardList,
-    () => {
+    (resp) => {
+      if (resp.code === 0) {
+        useGlobalStore.setState({
+          message: 'Claim 成功',
+          messageType: 'success',
+          messageOpen: true,
+        });
+      } else {
+        useGlobalStore.setState({
+          message: 'Claim 失败',
+          messageType: 'error',
+          messageOpen: true,
+        });
+      }
       getReward();
     },
     () => {
+      useGlobalStore.setState({
+        message: 'Claim 失败',
+        messageType: 'error',
+        messageOpen: true,
+      });
       getReward();
     }
   );
@@ -128,9 +142,11 @@ const Claim = (props: { price?: string }) => {
           <TableContainer
             sx={{
               marginTop: 0,
+              maxHeight: '500px', // 设置固定高度
+              overflowY: 'auto', // 添加垂直滚动
             }}
           >
-            <Table aria-label="simple table">
+            <Table aria-label="simple table" stickyHeader={true}>
               <TableHead>
                 <TableRow>
                   <TableCell

--- a/src/welcome/Profile/Reward.tsx
+++ b/src/welcome/Profile/Reward.tsx
@@ -84,22 +84,22 @@ const Reward = () => {
       <div className="mx-6 flex items-center justify-between">
         <div className="flex space-x-[34px]">
           <div className="flex flex-col items-center space-y-1">
-            <div className="flex space-x-1 items-center">
+            <div className="flex items-center space-x-1">
               <Icon />
-              <span className="text-xs text-[#0F1419] font-medium">12.4</span>
+              <span className="text-xs font-medium text-[#0F1419]">12.4</span>
             </div>
-            <span className="text-[#919099] text-[15px] font-medium">Pool</span>
+            <span className="text-[15px] font-medium text-[#919099]">Pool</span>
           </div>
 
           <div className="flex flex-col items-center space-y-1">
-            <div className="flex space-x-1 items-center">
+            <div className="flex items-center space-x-1">
               <Icon />
               <NumberDisplayer
-                className="text-xs text-[#0F1419] font-medium"
+                className="text-xs font-medium text-[#0F1419]"
                 text={userInfo?.rewardEarned}
               />
             </div>
-            <span className="text-[#919099] text-[15px] font-medium">Your Reward</span>
+            <span className="text-[15px] font-medium text-[#919099]">Your Reward</span>
           </div>
         </div>
 
@@ -164,9 +164,9 @@ const Reward = () => {
               padding: 0,
             }}
           >
-            <ul className="py-[22px] border-t border-t-[#EBEEF0]">
+            <ul className="border-t border-t-[#EBEEF0] py-[22px]">
               {tweetList?.map((item, i) => (
-                <li key={i} className="space-y-2 mb-4">
+                <li key={i} className="mb-4 space-y-2">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-[6px]">
                       <img
@@ -176,7 +176,7 @@ const Reward = () => {
                         }}
                         src={item.author?.avatar}
                         alt=""
-                        className="w-[44px] rounded-full cursor-pointer"
+                        className="w-[44px] cursor-pointer rounded-full"
                       />
                       <div className="flex flex-col space-y-[2px]">
                         <span className="text-sm font-bold" style={{ fontVariant: 'small-caps' }}>
@@ -194,7 +194,7 @@ const Reward = () => {
                     <span className="text-sm font-medium">#{item.rank}</span>
                   </div>
 
-                  <p className="text-black text-xs leading-[20px]">{item.text}</p>
+                  <p className="text-xs leading-[20px] text-black">{item.text}</p>
 
                   <Divider
                     sx={{
@@ -213,16 +213,16 @@ const Reward = () => {
               padding: 0,
             }}
           >
-            <ul className="py-[22px] border-t border-t-[#EBEEF0]">
+            <ul className="border-t border-t-[#EBEEF0] py-[22px]">
               {currentIndex >= 0 ? (
-                <li key={0} className="space-y-2 mb-4">
+                <li key={0} className="mb-4 space-y-2">
                   <div className="flex items-center justify-between">
                     <div className="flex items-center space-x-[6px]">
                       <img
                         onClick={() => openProfile(tweetList?.[currentIndex].author)}
                         src={tweetList?.[currentIndex].author?.avatar}
                         alt=""
-                        className="w-[44px] rounded-full cursor-pointer"
+                        className="w-[44px] cursor-pointer rounded-full"
                       />
                       <div className="flex flex-col space-y-[2px]">
                         <span className="text-sm font-bold" style={{ fontVariant: 'small-caps' }}>
@@ -242,7 +242,7 @@ const Reward = () => {
                     <span className="text-sm font-medium">#{tweetList?.[currentIndex].rank}</span>
                   </div>
 
-                  <p className="text-black text-xs leading-[20px]">
+                  <p className="text-xs leading-[20px] text-black">
                     {tweetList?.[currentIndex].text}
                   </p>
 


### PR DESCRIPTION
- Claim后端改用 multicall，前端接口适配，新增claim成功toast。
- Claim Toast 页面列表长度过长的时候，支持可滑动，设置最大高度。
- （开发特性）暂时每次只claim用户可以claim奖励的前两个，不然每次claim所有，都需要后端重新补数据